### PR TITLE
Firing click listeners is without doing a server side roundtrip

### DIFF
--- a/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -324,6 +324,7 @@ public class Button extends GeneratedVaadinButton<Button>
      * 
      * @deprecated use {@link #fireClick()} or {@link #fireClickInClient()} instead.
      */
+    @Deprecated
     public void click() {
         fireEvent(new ClickEvent<>(this, false, 0,0,0,0,0,0,false,false,false,false));
     }

--- a/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -321,8 +321,25 @@ public class Button extends GeneratedVaadinButton<Button>
     /**
      * Executes a click on this button at the client-side. Calling this method
      * behaves exactly the same as if the user would have clicked on the button.
+     * 
+     * @deprecated use {@link #fireClick()} or {@link #fireClickInClient()} instead.
      */
     public void click() {
+        fireEvent(new ClickEvent<>(this, false, 0,0,0,0,0,0,false,false,false,false));
+    }
+    
+    /**
+     * Executes all click listeners directly on the server side.
+     */
+    public void fireClick() {
+        fireEvent(new ClickEvent<>(this, false, 0,0,0,0,0,0,false,false,false,false));
+    }
+
+    /**
+     * Executes a click on this button at the client-side. Calling this method
+     * behaves the same as if the user would have clicked on the button.
+     */
+    public void fireClickInClient() {
         getElement().callFunction("click");
     }
 

--- a/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -319,28 +319,21 @@ public class Button extends GeneratedVaadinButton<Button>
     }
 
     /**
-     * Executes a click on this button at the client-side. Calling this method
-     * behaves exactly the same as if the user would have clicked on the button.
+     * Simulates a click on this button on the server side. Calling this method
+     * executes all registered click listeners on the server side, but does not 
+     * execute possible client side registered listeners.
      * 
-     * @deprecated use {@link #fireClick()} or {@link #fireClickInClient()} instead.
+     * @see #clickInClient() 
      */
-    @Deprecated
     public void click() {
         fireEvent(new ClickEvent<>(this, false, 0,0,0,0,0,0,false,false,false,false));
     }
     
     /**
-     * Executes all click listeners directly on the server side.
-     */
-    public void fireClick() {
-        fireEvent(new ClickEvent<>(this, false, 0,0,0,0,0,0,false,false,false,false));
-    }
-
-    /**
      * Executes a click on this button at the client-side. Calling this method
      * behaves the same as if the user would have clicked on the button.
      */
-    public void fireClickInClient() {
+    public void clickInClient() {
         getElement().callFunction("click");
     }
 

--- a/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.button.tests;
 
+import com.helger.commons.mutable.MutableBoolean;
 import java.util.function.Predicate;
 
 import org.junit.Assert;
@@ -221,6 +222,19 @@ public class ButtonTest {
 
         button.setText("bar");
         Assert.assertEquals("prefix", icon.getElement().getAttribute("slot"));
+    }
+
+    @Test
+    public void testFireClick() {
+        button = new Button();
+        MutableBoolean clicked = new MutableBoolean(false);
+        button.addClickListener(e-> {
+            clicked.set(true);
+        });
+        
+        Assert.assertFalse(clicked.booleanValue());
+        button.fireClick();
+        Assert.assertTrue(clicked.booleanValue());
     }
 
     private void assertOnlyChildIsText() {

--- a/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -236,7 +236,7 @@ public class ButtonTest {
         });
         
         Assert.assertFalse(clicked.booleanValue());
-        button.fireClick();
+        button.click();
         Assert.assertTrue(clicked.booleanValue());
     }
     


### PR DESCRIPTION

closes #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button-flow/94)
<!-- Reviewable:end -->
