### PR TITLE
Deprecate GeneratedVaadinButton#setDisabled method

### DIFF
--- a/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -197,7 +197,11 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      *
      * @param disabled
      *            the boolean value to set
+     *
+     * @deprecated Since 3.0, this API is deprecated in favor of
+     *             {@link Button#setEnabled(boolean)}
      */
+    @Deprecated
     protected void setDisabled(boolean disabled) {
         getElement().setProperty("disabled", disabled);
     }


### PR DESCRIPTION
`GeneratedVaadinButton#setDisabled` is a protected method, but users extending it or `Button` could still be using this method.

`Button#setEnabled` should be the only way to disable/enable the component.